### PR TITLE
Don't disableIRQ around catpureCounter() - doesn't seem needed

### DIFF
--- a/src/STMLowLevelTimer.cpp
+++ b/src/STMLowLevelTimer.cpp
@@ -232,9 +232,7 @@ uint32_t STMLowLevelTimer::captureCounter()
 {
     uint32_t elapsed = 0;
 
-    disableIRQ();
     elapsed = __HAL_TIM_GET_COUNTER(&TimHandle);
-    enableIRQ();
     return elapsed;
 }
 


### PR DESCRIPTION
This cuts additional 0.6us from Timer::sync() (compared to https://github.com/lancaster-university/codal-core/pull/85)
