### PR TITLE
Cut out FSMC HAL

### DIFF
--- a/inc/FSMCIO.h
+++ b/inc/FSMCIO.h
@@ -8,10 +8,22 @@
 namespace codal
 {
 
-ScreenIO *createParallelScreenIO(uint32_t flags, PinNumber wr, PinNumber rd);
+class FSMCIO : public ScreenIO
+{
+public:
+    DMA_HandleTypeDef hdma;
+    PVoidCallback doneHandler;
+    void *handlerArg;
+
+    FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd);
+    virtual void send(const void *txBuffer, uint32_t txSize);
+    virtual void startSend(const void *txBuffer, uint32_t txSize, PVoidCallback doneHandler,
+                           void *handlerArg);
+};
+
 
 } // namespace codal
 
-#define CODAL_CREATE_PARALLEL_SCREEN_IO codal::createParallelScreenIO
+#define CODAL_CREATE_PARALLEL_SCREEN_IO new codal::FSMCIO
 
 #endif

--- a/inc/FSMCIO.h
+++ b/inc/FSMCIO.h
@@ -1,32 +1,17 @@
 #ifndef FSMCIO_H
 #define FSMCIO_H
 
-#include "ST7735.h"
-#include "ZPin.h"
-
-#ifdef FSMC_Bank1
+#include "SPI.h"
+#include "Pin.h"
+#include "ScreenIO.h"
 
 namespace codal
 {
 
-class FSMCIO : public ScreenIO
-{
-public:
-    SRAM_HandleTypeDef hsram;
-    DMA_HandleTypeDef hdma;
-    PVoidCallback doneHandler;
-    void *handlerArg;
-
-    FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd);
-    virtual void send(const void *txBuffer, uint32_t txSize);
-    virtual void startSend(const void *txBuffer, uint32_t txSize, PVoidCallback doneHandler,
-                           void *handlerArg);
-};
+ScreenIO *createParallelScreenIO(uint32_t flags, PinNumber wr, PinNumber rd);
 
 } // namespace codal
 
-#define PARALLEL_SCREEN_IO codal::FSMCIO
-
-#endif
+#define CODAL_CREATE_PARALLEL_SCREEN_IO codal::createParallelScreenIO
 
 #endif

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -59,10 +59,6 @@
 #define PC_14 0x2E
 #define PC_15 0x2F
 #define PD_2 0x32
-#if defined(STM32F412Zx) || defined(STM32F412Vx)
-#define PD_4 0x34
-#define PD_5 0x35
-#endif
 #define PH_0 0x70
 #define PH_1 0x71
 

--- a/src/FSMCIO.cpp
+++ b/src/FSMCIO.cpp
@@ -1,70 +1,39 @@
+// redefine MCU type as one with the FSMC peripheral
+#ifdef STM32F401xE
+#undef STM32F401xE
+#define STM32F412Zx
+#endif
+
 #include "FSMCIO.h"
 #include "dma.h"
+
+// define missing pins
+#define PD_4 0x34
+#define PD_5 0x35
 
 #define ZERO(f) memset(&f, 0, sizeof(f))
 #define oops() target_panic(909)
 
-#ifdef FSMC_Bank1
-
 namespace codal
 {
 
-static void FMC_BANK1_Init(uint32_t flags, SRAM_HandleTypeDef &hsram)
+class FSMCIO : public ScreenIO
 {
-    FMC_NORSRAM_TimingTypeDef sram_timing;
-    FMC_NORSRAM_TimingTypeDef sram_timing_write;
+public:
+    DMA_HandleTypeDef hdma;
+    PVoidCallback doneHandler;
+    void *handlerArg;
 
-    /*** Configure the SRAM Bank 1 ***/
-    /* Configure IPs */
-    hsram.Instance = FSMC_Bank1;
-    hsram.Extended = FSMC_Bank1E;
-
-    /* Timing for READING */
-    sram_timing.AddressSetupTime = 9;
-    sram_timing.AddressHoldTime = 1;
-    sram_timing.DataSetupTime = 36;
-    sram_timing.BusTurnAroundDuration = 1;
-    sram_timing.CLKDivision = 2;
-    sram_timing.DataLatency = 2;
-    sram_timing.AccessMode = FSMC_ACCESS_MODE_A;
-
-    /* Timing for WRITTING*/
-    sram_timing_write.AddressSetupTime = 0;
-    sram_timing_write.AddressHoldTime = 1;
-    // 4 gives 72ns write cycle, datasheet for ILI9341 says 66ns min
-    // 3 gives 60ns
-    // everything works down to 1
-    sram_timing_write.DataSetupTime = flags & 0x1f;
-    sram_timing_write.BusTurnAroundDuration = 0;
-    sram_timing_write.CLKDivision = 2;
-    sram_timing_write.DataLatency = 2;
-    sram_timing_write.AccessMode = FSMC_ACCESS_MODE_A;
-
-    hsram.Init.NSBank = FSMC_NORSRAM_BANK1;
-    hsram.Init.DataAddressMux = FSMC_DATA_ADDRESS_MUX_DISABLE;
-    hsram.Init.MemoryType = FSMC_MEMORY_TYPE_SRAM;
-    hsram.Init.MemoryDataWidth = FSMC_NORSRAM_MEM_BUS_WIDTH_8;
-    hsram.Init.BurstAccessMode = FSMC_BURST_ACCESS_MODE_DISABLE;
-    hsram.Init.WaitSignalPolarity = FSMC_WAIT_SIGNAL_POLARITY_LOW;
-    hsram.Init.WrapMode = FSMC_WRAP_MODE_DISABLE;
-    hsram.Init.WaitSignalActive = FSMC_WAIT_TIMING_BEFORE_WS;
-    hsram.Init.WriteOperation = FSMC_WRITE_OPERATION_ENABLE;
-    hsram.Init.WaitSignal = FSMC_WAIT_SIGNAL_DISABLE;
-    hsram.Init.ExtendedMode = FSMC_EXTENDED_MODE_ENABLE;
-    hsram.Init.AsynchronousWait = FSMC_ASYNCHRONOUS_WAIT_DISABLE;
-    hsram.Init.WriteBurst = FSMC_WRITE_BURST_DISABLE;
-    hsram.Init.WriteFifo = FSMC_WRITE_FIFO_DISABLE;
-    hsram.Init.PageSize = FSMC_PAGE_SIZE_NONE;
-    hsram.Init.ContinuousClock = FSMC_CONTINUOUS_CLOCK_SYNC_ONLY;
-
-    HAL_SRAM_Init(&hsram, &sram_timing, &sram_timing_write);
-}
+    FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd);
+    virtual void send(const void *txBuffer, uint32_t txSize);
+    virtual void startSend(const void *txBuffer, uint32_t txSize, PVoidCallback doneHandler,
+                           void *handlerArg);
+};
 
 static FSMCIO *theInstance;
 
 FSMCIO::FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd)
 {
-    ZERO(hsram);
     ZERO(hdma);
 
     theInstance = this;
@@ -98,9 +67,9 @@ FSMCIO::FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd)
         gpio_init_structure.Pin = GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10;
         HAL_GPIO_Init(GPIOE, &gpio_init_structure);
     }
-    else 
+    else
 #endif
-    if (wr == PC_2 || wr == PD_2)
+        if (wr == PC_2 || wr == PD_2)
     {
         if (hasRead && rd != PC_5)
             oops();
@@ -134,9 +103,19 @@ FSMCIO::FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd)
         oops();
     }
 
-    FMC_BANK1_Init(flags, hsram);
+    // 4 gives 72ns write cycle, datasheet for ILI9341 says 66ns min
+    // 3 gives 60ns
+    // everything works down to 1
+    uint32_t datast = flags & 0xff;
+
+    FSMC_Bank1->BTCR[0] = FSMC_BCR1_EXTMOD | FSMC_BCR1_WREN | FSMC_BCR1_WFDIS |
+                          0x80;                       // 0x80 is reserved bit reset value
+    FSMC_Bank1->BTCR[1] = 0x112419;                   // timing for reading
+    FSMC_Bank1E->BWTR[0] = 0xff00010 | (datast << 8); // timing for writing
+
+    FSMC_Bank1->BTCR[0] |= FSMC_BCR1_MBKEN;
+
     dma_init(0, DMA_TX, &hdma, 0);
-    __HAL_LINKDMA(&hsram, hdma, hdma);
 }
 
 #define FSMC_DATA *((volatile uint8_t *)0x60000000)
@@ -163,11 +142,14 @@ void FSMCIO::startSend(const void *txBuffer, uint32_t txSize, PVoidCallback done
 {
     this->doneHandler = doneHandler;
     this->handlerArg = handlerArg;
-    hsram.hdma->XferCpltCallback = HAL_SRAM_DMA_XferCpltCallback;
-    hsram.hdma->XferErrorCallback = HAL_SRAM_DMA_XferErrorCallback;
-    HAL_DMA_Start_IT(hsram.hdma, (uint32_t)txBuffer, (uint32_t)&FSMC_DATA, txSize);
+    hdma.XferCpltCallback = HAL_SRAM_DMA_XferCpltCallback;
+    hdma.XferErrorCallback = HAL_SRAM_DMA_XferErrorCallback;
+    HAL_DMA_Start_IT(&hdma, (uint32_t)txBuffer, (uint32_t)&FSMC_DATA, txSize);
+}
+
+ScreenIO *createParallelScreenIO(uint32_t flags, PinNumber wr, PinNumber rd)
+{
+    return new FSMCIO(flags, wr, rd);
 }
 
 } // namespace codal
-
-#endif

--- a/src/FSMCIO.cpp
+++ b/src/FSMCIO.cpp
@@ -17,19 +17,6 @@
 namespace codal
 {
 
-class FSMCIO : public ScreenIO
-{
-public:
-    DMA_HandleTypeDef hdma;
-    PVoidCallback doneHandler;
-    void *handlerArg;
-
-    FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd);
-    virtual void send(const void *txBuffer, uint32_t txSize);
-    virtual void startSend(const void *txBuffer, uint32_t txSize, PVoidCallback doneHandler,
-                           void *handlerArg);
-};
-
 static FSMCIO *theInstance;
 
 FSMCIO::FSMCIO(uint32_t flags, PinNumber wr, PinNumber rd)
@@ -145,11 +132,6 @@ void FSMCIO::startSend(const void *txBuffer, uint32_t txSize, PVoidCallback done
     hdma.XferCpltCallback = HAL_SRAM_DMA_XferCpltCallback;
     hdma.XferErrorCallback = HAL_SRAM_DMA_XferErrorCallback;
     HAL_DMA_Start_IT(&hdma, (uint32_t)txBuffer, (uint32_t)&FSMC_DATA, txSize);
-}
-
-ScreenIO *createParallelScreenIO(uint32_t flags, PinNumber wr, PinNumber rd)
-{
-    return new FSMCIO(flags, wr, rd);
 }
 
 } // namespace codal


### PR DESCRIPTION
  - can now compile for F401 and still get FSMCIO

In PXT we generally compile for F401, which runs on F412 due to backward compat. With the previous driver we would have to compile for F412 and hope for forward compat so that everything except for FSMC also runs on F401. I would rather not take chances and compile everything for F401 and cut out the HAL driver (which boils down to 4 memory writes anyways).
